### PR TITLE
Add script fix for RNCSafeAreaProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "postinstall": "rm -rf node_modules/expo/node_modules/react-native-safe-area-context",
     "eject": "expo eject"
   },
   "dependencies": {


### PR DESCRIPTION
Doing a fresh `npm install` when new dependencies are added to the project will cause a runtime error to pop up:

`Tried to register two views with the same name RNCSafeAreaProvider`

Usage: Type in terminal `npm run postinstall` **AFTER** running the `npm install` on the project.

Script thanks to @dominik992 

