### PR TITLE
Allow capability to save settings to async storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-community/async-storage": "~1.11.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.2",
     "@react-navigation/native": "^5.7.1",

--- a/src/components/platelist/PlateList.tsx
+++ b/src/components/platelist/PlateList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   FlatList,
   View,
@@ -7,33 +7,40 @@ import {
   TouchableOpacity,
 } from "react-native";
 import PlateListSeparator from "../ItemListSeparator";
-import { PlateConfig, Plates } from "../../utils/PlateCalculation";
+import { PlateConfig, Plate } from "../../utils/PlateCalculation";
 import { MaterialIcons } from "@expo/vector-icons";
 import IncrementButton from "../../components/button/IncrementButton";
 
+// Prop-Type enforcement for the components in this module.
 type PlateListProps = {
   plateConfiguration: PlateConfig;
+  currentSelection: Set<Plate>;
+  onUpdateCurrentSelection?: (selection: Set<Plate>) => void;
+  onIncrementUpdate?: (plate: Plate, newAmount: number) => void;
   custom: boolean;
 };
 
 type PlateIncrementerProps = {
-  amount: number;
+  plate: Plate;
+  onAmountUpdate?: (plate: Plate, newAmount: number) => void;
 };
+// Prop-Type enforcement for the components in this module.
 
 /**
- * The incrementer component for the amount of plates available for each DefaultPlateItem
+ * The incrementer component for the amount of plates available for each PlateItem
  */
-const IncrementerComponent: React.FC<PlateIncrementerProps> = ({ amount }) => {
-  const [currAmount, changeAmount] = useState(amount);
-
+const PlateIncrementerComponent: React.FC<PlateIncrementerProps> = ({
+  plate,
+  onAmountUpdate,
+}) => {
   return (
     <View style={{ flexDirection: "row" }}>
       <Text style={[styles.plateNumberText, { marginRight: 12 }]}>
-        {currAmount}
+        {plate.amount}
       </Text>
       <IncrementButton
-        onIncrementPressed={() => changeAmount(currAmount + 1)}
-        onDecrementPressed={() => changeAmount(currAmount - 1)}
+        onIncrementPressed={() => onAmountUpdate?.(plate, plate.amount + 1)}
+        onDecrementPressed={() => onAmountUpdate?.(plate, plate.amount - 1)}
       />
     </View>
   );
@@ -45,7 +52,7 @@ const IncrementerComponent: React.FC<PlateIncrementerProps> = ({ amount }) => {
  * @param plates The current plate that has been tapped on.
  * @param selectedPlates The set of plates that have been already selected.
  */
-const showCheckMark = (plates: Plates, selectedPlates: Set<Plates>) => {
+const showCheckMark = (plates: Plate, selectedPlates: Set<Plate>) => {
   if (selectedPlates.has(plates)) {
     return <MaterialIcons name="check" size={24} color="red" />;
   } else {
@@ -54,50 +61,60 @@ const showCheckMark = (plates: Plates, selectedPlates: Set<Plates>) => {
 };
 
 /**
- * Display weighted plates in a list.
+ * Handles removing plates from the current selection set.
+ *
+ * @param plates The plate that has been tapped on.
+ * @param selectedPlates The set currently selected plates.
+ * @param action A callback function for when the selection set has changed.
+ */
+const handleSelection = (
+  plates: Plate,
+  selectedPlates: Set<Plate>,
+  action?: (plate: Set<Plate>) => void
+) => {
+  if (selectedPlates.has(plates)) {
+    let newSet = new Set(
+      [...selectedPlates].filter((x) => x.type != plates.type)
+    );
+    action?.(newSet);
+  } else {
+    // remove plate from the selected set.
+    let newSet = new Set([...selectedPlates, plates]);
+    action?.(newSet);
+  }
+};
+
+/**
+ * Display weighted plates in a list, handles components like plate selection and plate amounts.
  *
  * @param plateConfiguration the PlateConfig that will be used to display what kind of plates are available.
  */
 export const PlateList: React.FC<PlateListProps> = ({
+  currentSelection,
   plateConfiguration,
+  onUpdateCurrentSelection,
+  onIncrementUpdate,
   custom,
 }) => {
   const { availablePlates } = plateConfiguration;
-  const [selectedPlates, updateSelection] = useState(new Set<Plates>());
-  // TODO: Pre-checked plates should be passed as a prop.
-  // This sets the default checked plates to this list.
-  useEffect(() => {
-    const defaultSelection = availablePlates.filter((plate) =>
-      [45, 35, 25, 10, 5, 2.5].includes(plate.type)
-    );
-    updateSelection(new Set(defaultSelection));
-  }, [plateConfiguration]);
 
-  const handleSelection = (plates: Plates) => {
-    if (selectedPlates.has(plates)) {
-      let newSet = new Set(
-        [...selectedPlates].filter((x) => x.type != plates.type)
-      );
-      updateSelection(newSet);
-    } else {
-      // remove plate from the selected set.
-      let newSet = new Set([...selectedPlates, plates]);
-      updateSelection(newSet);
-    }
-  };
-
-  const DefaultPlateItem = (plate: Plates, customMode: boolean) => {
+  const PlateItem = (plate: Plate, customMode: boolean) => {
     return (
       <TouchableOpacity
-        onPress={() => handleSelection(plate)}
+        onPress={() =>
+          handleSelection(plate, currentSelection, onUpdateCurrentSelection)
+        }
         disabled={customMode}
         style={styles.container}
       >
         <Text style={styles.plateText}>{plate.type} lb</Text>
         {customMode ? (
-          <IncrementerComponent amount={0} />
+          <PlateIncrementerComponent
+            plate={plate}
+            onAmountUpdate={onIncrementUpdate}
+          />
         ) : (
-          showCheckMark(plate, selectedPlates)
+          showCheckMark(plate, currentSelection)
         )}
       </TouchableOpacity>
     );
@@ -106,12 +123,12 @@ export const PlateList: React.FC<PlateListProps> = ({
   return (
     <>
       <FlatList
-        data={availablePlates}
+        data={availablePlates.sort((a, b) => b.type - a.type)}
         ItemSeparatorComponent={PlateListSeparator}
         ListHeaderComponent={PlateListSeparator}
         ListFooterComponent={PlateListSeparator}
         renderItem={({ item: plate }) => {
-          return <>{DefaultPlateItem(plate, custom)}</>;
+          return <>{PlateItem(plate, custom)}</>;
         }}
         keyExtractor={(plate) => `${plate.type}`}
       />
@@ -119,7 +136,6 @@ export const PlateList: React.FC<PlateListProps> = ({
   );
 };
 
-// Style objects for the plate list function component.
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",

--- a/src/components/platelist/PlateList.tsx
+++ b/src/components/platelist/PlateList.tsx
@@ -14,8 +14,8 @@ import IncrementButton from "../../components/button/IncrementButton";
 // Prop-Type enforcement for the components in this module.
 type PlateListProps = {
   plateConfiguration: PlateConfig;
-  currentSelection: Set<Plate>;
-  onUpdateCurrentSelection?: (selection: Set<Plate>) => void;
+  currentSelection: Set<number>;
+  onUpdateCurrentSelection?: (selection: Set<number>) => void;
   onIncrementUpdate?: (plate: Plate, newAmount: number) => void;
   custom: boolean;
 };
@@ -49,11 +49,11 @@ const PlateIncrementerComponent: React.FC<PlateIncrementerProps> = ({
 /**
  * Returns a checkmark component if the plate is selected or null component if it isn't.
  *
- * @param plates The current plate that has been tapped on.
+ * @param plate The current plate that has been tapped on.
  * @param selectedPlates The set of plates that have been already selected.
  */
-const showCheckMark = (plates: Plate, selectedPlates: Set<Plate>) => {
-  if (selectedPlates.has(plates)) {
+const showCheckMark = (plate: Plate, selectedPlates: Set<number>) => {
+  if (selectedPlates.has(plate.type)) {
     return <MaterialIcons name="check" size={24} color="red" />;
   } else {
     return null;
@@ -63,23 +63,23 @@ const showCheckMark = (plates: Plate, selectedPlates: Set<Plate>) => {
 /**
  * Handles removing plates from the current selection set.
  *
- * @param plates The plate that has been tapped on.
+ * @param plate The plate that has been tapped on.
  * @param selectedPlates The set currently selected plates.
  * @param action A callback function for when the selection set has changed.
  */
 const handleSelection = (
-  plates: Plate,
-  selectedPlates: Set<Plate>,
-  action?: (plate: Set<Plate>) => void
+  plate: Plate,
+  selectedPlates: Set<number>,
+  action?: (plate: Set<number>) => void
 ) => {
-  if (selectedPlates.has(plates)) {
+  if (selectedPlates.has(plate.type)) {
     let newSet = new Set(
-      [...selectedPlates].filter((x) => x.type != plates.type)
+      [...selectedPlates].filter((plateType) => plateType != plate.type)
     );
     action?.(newSet);
   } else {
     // remove plate from the selected set.
-    let newSet = new Set([...selectedPlates, plates]);
+    let newSet = new Set([...selectedPlates, plate.type]);
     action?.(newSet);
   }
 };

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,44 +1,44 @@
-import React, { createContext, useReducer } from "react";
-import {
+import React, { createContext, useReducer, useEffect } from "react";
+import AsynStorage from "@react-native-community/async-storage";
+import StorageKeys, { setToJsonReplacer } from "../utils/StorageKeys";
+import PlateCalculation, {
   Plate,
   DefaultPlateConfig,
   PlateConfig,
   WeightConversions,
 } from "../utils/PlateCalculation";
 
-//TODO Store all of this in async.
 /**
  * Type restriction that contains all calculation settings for the barbell calculator.
  */
-type CalculationSettings = {
+interface CalculationSettings {
   // Boolean to check if custom plate numbers should be used.
   customMode: boolean;
   plateConfig: DefaultPlateConfig;
-  checkedPlates: Set<Plate>;
-};
+  checkedPlateTypes: Set<number>;
+}
 
 /**
  * Types of actions relative to user settings.
  */
 type SettingAction =
   | { type: "toggle_custom_plates"; isEnabled: boolean }
-  | { type: "update_checked_plates"; newSet: Set<Plate> }
+  | { type: "update_checked_plates"; newTypeSet: Set<number> }
   | { type: "update_plate_amount"; newPlate: Plate }
   | { type: "update_type_conversion"; conversionType: WeightConversions }
   | { type: "update_barbell_weight"; newWeight: number };
+
+type SettingStorageAction =
+  | { type: "save_user_settings" }
+  | { type: "update_user_settings"; updatedSettings: CalculationSettings };
 
 /**
  * Interface that describes the types of data that will be in the settings provider.
  */
 interface SettingsContextProp {
   state: CalculationSettings;
-  dispatch: React.Dispatch<SettingAction>;
+  dispatch: React.Dispatch<SettingAction | SettingStorageAction>;
 }
-
-//TODO Get default se ttings from async storage.
-const defaultSettings = {} as SettingsContextProp;
-const Context = createContext(defaultSettings);
-const { Provider } = Context;
 
 /**
  * This reducer is mainly used to update the settings for the barbell calculation.
@@ -46,12 +46,15 @@ const { Provider } = Context;
  * @param state the CalculationSettings object
  * @param action the action type and payload object used to update the current state of the settings.
  */
-const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
+const settingsReducer = (
+  state: CalculationSettings,
+  action: SettingAction | SettingStorageAction
+) => {
   switch (action.type) {
     case "toggle_custom_plates":
       return { ...state, customMode: action.isEnabled };
     case "update_checked_plates":
-      return { ...state, checkedPlates: action.newSet };
+      return { ...state, checkedPlateTypes: action.newTypeSet };
     case "update_plate_amount":
       const newConfig = updateConfigPlateAmount(
         state.plateConfig,
@@ -68,6 +71,11 @@ const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
       currPlateConfig.barbellWeight = action.newWeight;
       return { ...state, plateConfig: currPlateConfig };
     }
+    case "save_user_settings":
+      saveSettings(state);
+      return state;
+    case "update_user_settings":
+      return action.updatedSettings;
     default:
       return state;
   }
@@ -79,30 +87,97 @@ const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
  * @param currPlateConfig The current plate configuration that will be updated.
  * @param newPlateState The new plate that will be used to update the available plates in the currPlateConfig
  */
-function updateConfigPlateAmount(
+const updateConfigPlateAmount = (
   currPlateConfig: PlateConfig,
   newPlateState: Plate
-): PlateConfig {
+): PlateConfig => {
   const updateIndex = currPlateConfig.availablePlates.findIndex(
     (plate) => plate.type == newPlateState.type
   );
   currPlateConfig.availablePlates[updateIndex].amount = newPlateState.amount;
   return currPlateConfig;
-}
+};
+
+/**
+ * Asynchronously saves the CalculationSettings object into persistent storage.
+ *
+ * @param currSettings The current setting's object to save into storage.
+ */
+const saveSettings = async (currSettings: CalculationSettings) => {
+  try {
+    const settingsJson = JSON.stringify(currSettings, setToJsonReplacer);
+    await AsynStorage.setItem(StorageKeys.UserSettings, settingsJson);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+/**
+ *
+ */
+const getSettingsPersistent = async (): Promise<CalculationSettings> => {
+  const storedSettings = await AsynStorage.getItem(StorageKeys.UserSettings);
+
+  if (storedSettings != null) {
+    const parsedSettings: CalculationSettings = JSON.parse(
+      storedSettings
+    ) as CalculationSettings;
+    // Revert the checkedPlateTypes property back to a set.
+    parsedSettings.checkedPlateTypes = new Set<number>(
+      parsedSettings.checkedPlateTypes
+    );
+
+    return parsedSettings;
+  }
+  return constructDefaultSettings();
+};
+
+/**
+ * Returns a default initialized CalculationSettings object.
+ *
+ * @returns A CalculationSettings object.
+ */
+const constructDefaultSettings = (): CalculationSettings => {
+  const newPlateConfig = new DefaultPlateConfig();
+  // Filter and reduce the default plate numbers into a set of numbers.
+  const defaultCheckedPlates: Set<number> = newPlateConfig.availablePlates.reduce(
+    (defaultSet, currPlate: Plate) => {
+      if ([2.5, 5, 10, 25, 35, 45].includes(currPlate.type)) {
+        defaultSet.add(currPlate.type);
+      }
+      return defaultSet;
+    },
+    new Set<number>()
+  );
+  return {
+    customMode: false,
+    plateConfig: newPlateConfig,
+    checkedPlateTypes: defaultCheckedPlates,
+  };
+};
+
+// Setup for the settings provider
+const defaultSettings = {} as SettingsContextProp;
+const Context = createContext(defaultSettings);
+const { Provider } = Context;
 
 /**
  * Provides any requesting children the settings data.
  */
 const SettingsProvider: React.FunctionComponent = ({ children }) => {
-  const newPlateConfig = new DefaultPlateConfig();
-  const defaultCheckedPlates = newPlateConfig.availablePlates.filter((plate) =>
-    [45, 35, 25, 10, 5, 2.5].includes(plate.type)
+  // Create the default settings state and setup the reducer.
+  const [state, dispatch] = useReducer(
+    settingsReducer,
+    constructDefaultSettings()
   );
-  const [state, dispatch] = useReducer(settingsReducer, {
-    customMode: false,
-    plateConfig: newPlateConfig,
-    checkedPlates: new Set([...defaultCheckedPlates]),
-  });
+  // Run when user first launches app.
+  useEffect(() => {
+    // Get the stored user settings and update it to the current state.
+    getSettingsPersistent().then((userSettings: CalculationSettings) => {
+      dispatch({ type: "update_user_settings", updatedSettings: userSettings });
+    });
+  }, []);
+
   return <Provider value={{ state, dispatch }}>{children}</Provider>;
 };
 

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,22 +1,38 @@
 import React, { createContext, useReducer } from "react";
+import {
+  Plate,
+  DefaultPlateConfig,
+  PlateConfig,
+} from "../utils/PlateCalculation";
 
 //TODO Store all of this in async.
 /**
- * Class that contains all calculation settings for the barbell calculator.
+ * Type restriction that contains all calculation settings for the barbell calculator.
  */
 type CalculationSettings = {
   // Boolean to check if custom plate numbers should be used.
   customMode: boolean;
+  plateConfig: DefaultPlateConfig;
+  checkedPlates: Set<Plate>;
 };
 
-type SettingAction = { type: "toggle_custom_plates"; isEnabled: boolean };
+/**
+ * Types of actions relative to user settings.
+ */
+type SettingAction =
+  | { type: "toggle_custom_plates"; isEnabled: boolean }
+  | { type: "update_checked_plates"; newSet: Set<Plate> }
+  | { type: "update_plate_amount"; newPlate: Plate };
 
+/**
+ * Interface that describes the types of data that will be in the settings provider.
+ */
 interface SettingsContextProp {
   state: CalculationSettings;
   dispatch: React.Dispatch<SettingAction>;
 }
 
-//TODO Get default settings from async storage.
+//TODO Get default se ttings from async storage.
 const defaultSettings = {} as SettingsContextProp;
 const Context = createContext(defaultSettings);
 const { Provider } = Context;
@@ -28,17 +44,46 @@ const { Provider } = Context;
  * @param action the action type and payload object used to update the current state of the settings.
  */
 const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
-  if (action.type == "toggle_custom_plates") {
-    return { ...state, customMode: action.isEnabled };
+  switch (action.type) {
+    case "toggle_custom_plates":
+      return { ...state, customMode: action.isEnabled };
+    case "update_checked_plates":
+      return { ...state, checkedPlates: action.newSet };
+    case "update_plate_amount":
+      const newConfig = updateConfigPlateAmount(
+        state.plateConfig,
+        action.newPlate
+      );
+      return { ...state, plateConfig: newConfig };
+    default:
+      return state;
   }
-  return state;
 };
+
+function updateConfigPlateAmount(
+  currPlateConfig: PlateConfig,
+  newPlateState: Plate
+): PlateConfig {
+  const updateIndex = currPlateConfig.availablePlates.findIndex(
+    (plate) => plate.type == newPlateState.type
+  );
+  currPlateConfig.availablePlates[updateIndex].amount = newPlateState.amount;
+  return currPlateConfig;
+}
 
 /**
  * Provides any requesting children the settings data.
  */
 const SettingsProvider: React.FunctionComponent = ({ children }) => {
-  const [state, dispatch] = useReducer(settingsReducer, { customMode: true });
+  const newPlateConfig = new DefaultPlateConfig();
+  const defaultCheckedPlates = newPlateConfig.availablePlates.filter((plate) =>
+    [45, 35, 25, 10, 5, 2.5].includes(plate.type)
+  );
+  const [state, dispatch] = useReducer(settingsReducer, {
+    customMode: false,
+    plateConfig: newPlateConfig,
+    checkedPlates: new Set([...defaultCheckedPlates]),
+  });
   return <Provider value={{ state, dispatch }}>{children}</Provider>;
 };
 

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -24,7 +24,8 @@ type SettingAction =
   | { type: "toggle_custom_plates"; isEnabled: boolean }
   | { type: "update_checked_plates"; newSet: Set<Plate> }
   | { type: "update_plate_amount"; newPlate: Plate }
-  | { type: "update_type_conversion"; conversionType: WeightConversions };
+  | { type: "update_type_conversion"; conversionType: WeightConversions }
+  | { type: "update_barbell_weight"; newWeight: number };
 
 /**
  * Interface that describes the types of data that will be in the settings provider.
@@ -57,10 +58,16 @@ const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
         action.newPlate
       );
       return { ...state, plateConfig: newConfig };
-    case "update_type_conversion":
+    case "update_type_conversion": {
       const currPlateConfig = state.plateConfig;
       currPlateConfig.conversionType = action.conversionType;
       return { ...state, plateConfig: currPlateConfig };
+    }
+    case "update_barbell_weight": {
+      const currPlateConfig = state.plateConfig;
+      currPlateConfig.barbellWeight = action.newWeight;
+      return { ...state, plateConfig: currPlateConfig };
+    }
     default:
       return state;
   }

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -3,6 +3,7 @@ import {
   Plate,
   DefaultPlateConfig,
   PlateConfig,
+  WeightConversions,
 } from "../utils/PlateCalculation";
 
 //TODO Store all of this in async.
@@ -22,7 +23,8 @@ type CalculationSettings = {
 type SettingAction =
   | { type: "toggle_custom_plates"; isEnabled: boolean }
   | { type: "update_checked_plates"; newSet: Set<Plate> }
-  | { type: "update_plate_amount"; newPlate: Plate };
+  | { type: "update_plate_amount"; newPlate: Plate }
+  | { type: "update_type_conversion"; conversionType: WeightConversions };
 
 /**
  * Interface that describes the types of data that will be in the settings provider.
@@ -55,11 +57,21 @@ const settingsReducer = (state: CalculationSettings, action: SettingAction) => {
         action.newPlate
       );
       return { ...state, plateConfig: newConfig };
+    case "update_type_conversion":
+      const currPlateConfig = state.plateConfig;
+      currPlateConfig.conversionType = action.conversionType;
+      return { ...state, plateConfig: currPlateConfig };
     default:
       return state;
   }
 };
 
+/**
+ * A helper function that updates PlateConfig's plate amount.
+ *
+ * @param currPlateConfig The current plate configuration that will be updated.
+ * @param newPlateState The new plate that will be used to update the available plates in the currPlateConfig
+ */
 function updateConfigPlateAmount(
   currPlateConfig: PlateConfig,
   newPlateState: Plate

--- a/src/screens/settingscreen/BarWeightComponent.tsx
+++ b/src/screens/settingscreen/BarWeightComponent.tsx
@@ -11,8 +11,8 @@ const BarWeightComponent: React.FC = () => {
           {barWeight}
         </Text>
         <IncrementButton
-          onIncrementPressed={() => changeBarWeight(barWeight - 5)}
-          onDecrementPressed={() => changeBarWeight(barWeight + 5)}
+          onIncrementPressed={() => changeBarWeight(barWeight + 5)}
+          onDecrementPressed={() => changeBarWeight(barWeight - 5)}
         />
       </View>
     </>

--- a/src/screens/settingscreen/BarWeightComponent.tsx
+++ b/src/screens/settingscreen/BarWeightComponent.tsx
@@ -1,18 +1,32 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import { Text, View, StyleSheet } from "react-native";
 import IncrementButton from "../../components/button/IncrementButton";
+import { Context as SettingsContext } from "../../context/SettingsContext";
 
 const BarWeightComponent: React.FC = () => {
-  const [barWeight, changeBarWeight] = useState(45);
+  const settingsState = useContext(SettingsContext);
+  const { state: userSettings, dispatch } = settingsState;
+  const currBarWeight = userSettings.plateConfig.barbellWeight;
+
   return (
     <>
       <View style={{ flexDirection: "row" }}>
         <Text style={[styles.barWeightText, { marginRight: 12 }]}>
-          {barWeight}
+          {currBarWeight}
         </Text>
         <IncrementButton
-          onIncrementPressed={() => changeBarWeight(barWeight + 5)}
-          onDecrementPressed={() => changeBarWeight(barWeight - 5)}
+          onIncrementPressed={() =>
+            dispatch({
+              type: "update_barbell_weight",
+              newWeight: currBarWeight + 5,
+            })
+          }
+          onDecrementPressed={() =>
+            dispatch({
+              type: "update_barbell_weight",
+              newWeight: currBarWeight - 5,
+            })
+          }
         />
       </View>
     </>

--- a/src/screens/settingscreen/ConversionsComponent.tsx
+++ b/src/screens/settingscreen/ConversionsComponent.tsx
@@ -29,10 +29,7 @@ const ConversionsComponent = () => {
 
   return (
     <>
-      <TouchableOpacity
-        onPress={() => toggleConversion()}
-        style={styles.container}
-      >
+      <TouchableOpacity onPress={toggleConversion} style={styles.container}>
         <Text style={styles.weightTypeText}>
           {getConversionTypeStr(conversionType)}
         </Text>

--- a/src/screens/settingscreen/ConversionsComponent.tsx
+++ b/src/screens/settingscreen/ConversionsComponent.tsx
@@ -1,16 +1,41 @@
-import React, { useState } from "react";
-import { Text, View, TouchableOpacity, StyleSheet } from "react-native";
+import React, { useContext } from "react";
+import { Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Entypo } from "@expo/vector-icons";
+import { Context as SettingsContext } from "../../context/SettingsContext";
+import { WeightConversions, PlateConfig } from "../../utils/PlateCalculation";
 
 const ConversionsComponent = () => {
-  const [toggle, toggleType] = useState(false);
+  const { state: userSettings, dispatch } = useContext(SettingsContext);
+  const { conversionType } = userSettings.plateConfig;
+
+  const getConversionTypeStr = (type: WeightConversions) => {
+    switch (type) {
+      case WeightConversions.Kilograms:
+        return "Kg";
+      default:
+        return "Lb";
+    }
+  };
+
+  const toggleConversion = () => {
+    let newConvType = WeightConversions.Pounds;
+    if (conversionType == WeightConversions.Kilograms) {
+      newConvType = WeightConversions.Pounds;
+    } else {
+      newConvType = WeightConversions.Kilograms;
+    }
+    dispatch({ type: "update_type_conversion", conversionType: newConvType });
+  };
+
   return (
     <>
       <TouchableOpacity
-        onPress={() => toggleType(!toggle)}
+        onPress={() => toggleConversion()}
         style={styles.container}
       >
-        <Text style={styles.weightTypeText}>{toggle ? "Kg" : "Lb"}</Text>
+        <Text style={styles.weightTypeText}>
+          {getConversionTypeStr(conversionType)}
+        </Text>
         <Entypo
           name="chevron-thin-right"
           style={{ paddingLeft: 4 }}

--- a/src/screens/settingscreen/LimitedPlatesComponent.tsx
+++ b/src/screens/settingscreen/LimitedPlatesComponent.tsx
@@ -9,6 +9,7 @@ const LimitedPlatesComponent: React.FC = () => {
       type: "toggle_custom_plates",
       isEnabled: !userSettings.customMode,
     });
+
   return (
     <Switch
       trackColor={{ false: "#767577", true: "#81b0ff" }}

--- a/src/screens/settingscreen/LimitedPlatesComponent.tsx
+++ b/src/screens/settingscreen/LimitedPlatesComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useContext } from "react";
 import { Context as SettingsContext } from "../../context/SettingsContext";
 import { Switch } from "react-native";
 

--- a/src/screens/settingscreen/SettingScreen.tsx
+++ b/src/screens/settingscreen/SettingScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect } from "react";
-import { StyleSheet, Text, SafeAreaView, View } from "react-native";
+import React, { useContext } from "react";
+import { StyleSheet, Text, SafeAreaView, View, Button } from "react-native";
 import {
   OptionsList,
   OptionItem,
@@ -33,20 +33,26 @@ const optionItems: Array<OptionItem> = [
 const SettingScreen: React.FC = () => {
   const settingsState = useContext(SettingsContext);
   const { state: userSettings, dispatch } = settingsState;
-
   return (
     <>
       <SafeAreaView style={styles.container}>
         <Text style={styles.itemText}>This is the setting screen</Text>
+        <Button
+          title="SAVE"
+          onPress={() => dispatch({ type: "save_user_settings" })}
+        />
         <View style={{ marginTop: 10 }}>
           <OptionsList optionItemList={optionItems} />
           <View style={{ marginVertical: 16 }} />
           <PlateList
             plateConfiguration={userSettings.plateConfig}
             custom={userSettings.customMode}
-            currentSelection={userSettings.checkedPlates}
-            onUpdateCurrentSelection={(plates: Set<Plate>) => {
-              dispatch({ type: "update_checked_plates", newSet: plates });
+            currentSelection={userSettings.checkedPlateTypes}
+            onUpdateCurrentSelection={(availableTypes: Set<number>) => {
+              dispatch({
+                type: "update_checked_plates",
+                newTypeSet: availableTypes,
+              });
             }}
             onIncrementUpdate={(plate: Plate, amount: number) => {
               plate.amount = amount;

--- a/src/screens/settingscreen/SettingScreen.tsx
+++ b/src/screens/settingscreen/SettingScreen.tsx
@@ -1,10 +1,10 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { StyleSheet, Text, SafeAreaView, View } from "react-native";
 import {
   OptionsList,
   OptionItem,
 } from "../../components/optionlist/OptionList";
-import { DefaultPlateConfig } from "../../utils/PlateCalculation";
+import { Plate } from "../../utils/PlateCalculation";
 import { PlateList } from "../../components/platelist/PlateList";
 import BarWeightComponent from "./BarWeightComponent";
 import ConversionsComponent from "./ConversionsComponent";
@@ -31,12 +31,9 @@ const optionItems: Array<OptionItem> = [
 ];
 
 const SettingScreen: React.FC = () => {
-  // By default the DefaultPlateConfig.availablePlates is sorted from least to greatest so we must check
-  // if we have to reverse the array to display the list of available plates from greatest to least.
-  const defaultPlateConfig = new DefaultPlateConfig();
-  defaultPlateConfig.availablePlates = defaultPlateConfig.availablePlates.reverse();
   const settingsState = useContext(SettingsContext);
-  const { state: userSettings } = settingsState;
+  const { state: userSettings, dispatch } = settingsState;
+
   return (
     <>
       <SafeAreaView style={styles.container}>
@@ -45,8 +42,16 @@ const SettingScreen: React.FC = () => {
           <OptionsList optionItemList={optionItems} />
           <View style={{ marginVertical: 16 }} />
           <PlateList
-            plateConfiguration={defaultPlateConfig}
+            plateConfiguration={userSettings.plateConfig}
             custom={userSettings.customMode}
+            currentSelection={userSettings.checkedPlates}
+            onUpdateCurrentSelection={(plates: Set<Plate>) => {
+              dispatch({ type: "update_checked_plates", newSet: plates });
+            }}
+            onIncrementUpdate={(plate: Plate, amount: number) => {
+              plate.amount = amount;
+              dispatch({ type: "update_plate_amount", newPlate: plate });
+            }}
           />
         </View>
       </SafeAreaView>

--- a/src/utils/PlateCalculation.tsx
+++ b/src/utils/PlateCalculation.tsx
@@ -21,7 +21,7 @@ export interface Plate {
  */
 export interface PlateConfig {
   availablePlates: Array<Plate>;
-  conv: WeightConversions;
+  conversionType: WeightConversions;
   barbellWeight: number;
 }
 
@@ -55,7 +55,7 @@ export class DefaultPlateConfig {
     new StandardPlate(65, 0),
     new StandardPlate(100, 0),
   ];
-  conv: WeightConversions = WeightConversions.Pounds;
+  conversionType: WeightConversions = WeightConversions.Pounds;
   barbellWeight: number = 45;
 }
 

--- a/src/utils/PlateCalculation.tsx
+++ b/src/utils/PlateCalculation.tsx
@@ -9,7 +9,7 @@ export enum WeightConversions {
 /**
  * Interface to keep track of weighted plates and available amounts.
  */
-export interface Plates {
+export interface Plate {
   type: number;
   amount: number;
 }
@@ -20,7 +20,7 @@ export interface Plates {
  * @see calculateRequiredPlates
  */
 export interface PlateConfig {
-  availablePlates: Array<Plates>;
+  availablePlates: Array<Plate>;
   conv: WeightConversions;
   barbellWeight: number;
 }
@@ -43,7 +43,7 @@ class StandardPlate {
  * @see {@link https://en.wikipedia.org/wiki/Weight_plate#:~:text=Plates%20are%20available%20in%20a,pound%20plates%20less%20commonly%20seen. | Common PLates}
  */
 export class DefaultPlateConfig {
-  availablePlates: Array<Plates> = [
+  availablePlates: Array<Plate> = [
     new StandardPlate(1.25, 0),
     new StandardPlate(2.5, 0), // This plate is considered a 2.5 plate but value is 2 for ease of calculation.
     new StandardPlate(5, 0),
@@ -55,7 +55,7 @@ export class DefaultPlateConfig {
     new StandardPlate(65, 0),
     new StandardPlate(100, 0),
   ];
-  conv: WeightConversions = WeightConversions.Kilograms;
+  conv: WeightConversions = WeightConversions.Pounds;
   barbellWeight: number = 45;
 }
 
@@ -74,14 +74,14 @@ export class DefaultPlateConfig {
  */
 const calcRequiredPlatesStandard = (
   targetWeight: number
-): { plates?: Array<Plates>; leftoverWeight: number } => {
+): { plates?: Array<Plate>; leftoverWeight: number } => {
   // Target weight must be a value > 0 or else return default {undefined, -1} object.
   if (targetWeight <= 0) {
     return { plates: undefined, leftoverWeight: -1 };
   }
 
   const { availablePlates, barbellWeight } = new DefaultPlateConfig();
-  const platesResult = Array<Plates>();
+  const platesResult = Array<Plate>();
 
   // Calculate the weight for one side of the barbell.
   // EX: 135lbs - 45lbs = 90 / 2 => 45lbs per side.
@@ -89,7 +89,7 @@ const calcRequiredPlatesStandard = (
 
   // Since we're using pop() for Array, the array will be sorted from least to greatest. [25,35,45] <== 45lb will be popped and removed.
   while (target != 0 && availablePlates.length) {
-    const currHeaviestPlate: Plates =
+    const currHeaviestPlate: Plate =
       availablePlates[availablePlates.length - 1];
     if (currHeaviestPlate.type <= target) {
       const amountNeeded = Math.trunc(target / currHeaviestPlate.type);

--- a/src/utils/StorageKeys.tsx
+++ b/src/utils/StorageKeys.tsx
@@ -1,0 +1,21 @@
+/**
+ * Stores key names for the async storage.
+ */
+enum StorageKeys {
+  UserSettings = "@user_settings",
+}
+
+/**
+ * Replaces any Set<any> types and returns it as an array.
+ *
+ * @param key name of key in the json stringify results
+ * @param value the value of the object in the key value pair (key : value)
+ */
+export const setToJsonReplacer = (key: any, value: any) => {
+  if (typeof value === "object" && value instanceof Set) {
+    return [...value];
+  }
+  return value;
+};
+
+export default StorageKeys;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,6 +1069,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@react-native-community/async-storage@~1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.11.0.tgz#bf81b8813080846f150c67f531987c429b442166"
+  integrity sha512-Pq9LlmvtCEKAGdkyrgTcRxNh2fnHFykEj2qnRYijOl1pDIl2MkD5IxaXu5eOL0wgOtAl4U//ff4z40Td6XR5rw==
+  dependencies:
+    deep-assign "^3.0.0"
+
 "@react-native-community/cli-debugger-ui@^4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz#4177764ba69243c97aa26829d59d9501acb2bd71"


### PR DESCRIPTION
Closes #10 

Settings provider can now dispatch an action to save into persistent storage.

Usage:

To save current settings to storage simply call:
```javascript
dispatch({type: "save_user_settings"})
```

To update the **in-memory settings** simply call:
```javascript
dispatch({type:"update_user_settings", updatedSettings : <CalculationSettings>})
```